### PR TITLE
Switch nlines and nsamps

### DIFF
--- a/segment/src/gdal_io.c
+++ b/segment/src/gdal_io.c
@@ -89,7 +89,7 @@ GDAL_write_image(Seg_proc Spr, char *fname)
     char **papszOptions = NULL;
 
     hDstDs = GDALCreate(hDriver, fname,
-                        Spr->nlines, Spr->nsamps, 1,
+                        Spr->nsamps, Spr->nlines, 1,
                         eBufType, papszOptions);
     hBand = GDALGetRasterBand(hDstDs, 1);
 


### PR DESCRIPTION
This previously was making a dataset with flipped dimensions
which causes the loop below to fail when presented with a
non-square image.

The test doesn't catch this because the test image is square.